### PR TITLE
chore(deps-dev): bump the types group with 1 update (#931)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
                 "@types/hapi__catbox": "^10.2.6",
                 "@types/jsdom": "^21.1.6",
                 "@types/ms": "^0.7.34",
-                "@types/node": "^20.10.5",
+                "@types/node": "^20.10.6",
                 "@types/node-fetch": "^2.6.10",
                 "@typescript-eslint/eslint-plugin": "^6.16.0",
                 "@typescript-eslint/parser": "^6.16.0",
@@ -2649,9 +2649,9 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "20.10.5",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.5.tgz",
-            "integrity": "sha512-nNPsNE65wjMxEKI93yOP+NPGGBJz/PoN3kZsVLee0XMiJolxSekEVD8wRwBUBqkwc7UWop0edW50yrCQW4CyRw==",
+            "version": "20.10.6",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.6.tgz",
+            "integrity": "sha512-Vac8H+NlRNNlAmDfGUP7b5h/KA+AtWIzuXy0E6OyP8f1tCLYAtPvKRRDJjAPqhpCb0t6U2j7/xqAuLEebW2kiw==",
             "dependencies": {
                 "undici-types": "~5.26.4"
             }

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
         "@types/hapi__catbox": "^10.2.6",
         "@types/jsdom": "^21.1.6",
         "@types/ms": "^0.7.34",
-        "@types/node": "^20.10.5",
+        "@types/node": "^20.10.6",
         "@types/node-fetch": "^2.6.10",
         "@typescript-eslint/eslint-plugin": "^6.16.0",
         "@typescript-eslint/parser": "^6.16.0",


### PR DESCRIPTION
Bumps the types group with 1 update: [@types/node](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/HEAD/types/node).


Updates `@types/node` from 20.10.5 to 20.10.6
- [Release notes](https://github.com/DefinitelyTyped/DefinitelyTyped/releases)
- [Commits](https://github.com/DefinitelyTyped/DefinitelyTyped/commits/HEAD/types/node)

---
updated-dependencies:
- dependency-name: "@types/node" dependency-type: direct:development update-type: version-update:semver-patch dependency-group: types ...